### PR TITLE
[탈퇴뷰] 레이아웃 구조 변경

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,23 +1,17 @@
 import styled from 'styled-components';
 
 interface ButtonInterface {
-  color: string;
-  borderColor?: string;
   message: string;
   onClick: VoidFunction;
 }
 
-const Button = ({ color, borderColor, message, onClick }: ButtonInterface) => {
-  return (
-    <ButtonWrapper $color={color} $borderColor={borderColor} onClick={onClick}>
-      {message}
-    </ButtonWrapper>
-  );
+const Button = ({ message, onClick }: ButtonInterface) => {
+  return <ButtonWrapper onClick={onClick}>{message}</ButtonWrapper>;
 };
 
 export default Button;
 
-const ButtonWrapper = styled.div<{ $color: string; $borderColor?: string }>`
+const ButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -27,9 +21,8 @@ const ButtonWrapper = styled.div<{ $color: string; $borderColor?: string }>`
 
   font-size: 1.6rem;
   text-align: center;
-  color: ${({ theme, $color }) => theme.colors[$color]};
+  color: ${({ theme }) => theme.colors.white};
 
   border-radius: 1.8rem;
-  border: 1px solid
-    ${({ theme, $borderColor }) => ($borderColor ? theme.colors[$borderColor] : 'white')};
+  border: 1px solid ${({ theme }) => theme.colors.white};
 `;

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import { useDeleteUser } from '../hooks/queries/useDeleteUser';
+
+interface DeleteButtonInterface {
+  message: string;
+}
+
+const DeleteButton = ({ message }: DeleteButtonInterface) => {
+  const { deleteUser } = useDeleteUser();
+  const accessToken = localStorage.getItem('ACCESS_TOKEN');
+
+  if (!accessToken) {
+    console.error('Access token is missing');
+    return null;
+  }
+
+  const handleDeleteUser = () => {
+    deleteUser(accessToken);
+  };
+
+  return <ButtonWrapper onClick={handleDeleteUser}>{message}</ButtonWrapper>;
+};
+
+export default DeleteButton;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 26rem;
+  height: 5.2rem;
+
+  font-size: 1.6rem;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.red};
+
+  border-radius: 1.8rem;
+  border: 1px solid ${({ theme }) => theme.colors.red};
+`;

--- a/src/layouts/DeleteLayout.tsx
+++ b/src/layouts/DeleteLayout.tsx
@@ -1,17 +1,12 @@
 import styled from 'styled-components';
 import { IcFeelingLBlank, IcPcBlank, IcPcRecordream } from '../assets/svg';
-import Button from '../components/Button';
 import { Outlet } from 'react-router-dom';
-import { useDeleteUser } from '../hooks/queries/useDeleteUser';
 
 interface DeleteLayoutInterface {
   iconOn: boolean;
-  btnColor: string;
-  btnMessage: string;
 }
 
-const DeleteLayout = ({ iconOn, btnColor, btnMessage }: DeleteLayoutInterface) => {
-  const { deleteUser } = useDeleteUser();
+const DeleteLayout = ({ iconOn }: DeleteLayoutInterface) => {
   const accessToken = localStorage.getItem('ACCESS_TOKEN');
 
   console.log('ACCESSTOKEn', accessToken);
@@ -19,10 +14,6 @@ const DeleteLayout = ({ iconOn, btnColor, btnMessage }: DeleteLayoutInterface) =
     console.error('Access token is missing');
     return null;
   }
-
-  const handleDeleteUser = () => {
-    deleteUser(accessToken);
-  };
 
   return (
     <RecordreamLayoutWrapper>
@@ -33,7 +24,6 @@ const DeleteLayout = ({ iconOn, btnColor, btnMessage }: DeleteLayoutInterface) =
         <IcPcBlank style={{ width: 85, height: 85, marginTop: 74, marginBottom: 18 }} />
       )}
       <Outlet />
-      <Button color={btnColor} message={btnMessage} onClick={handleDeleteUser} />
     </RecordreamLayoutWrapper>
   );
 };

--- a/src/layouts/RecordreamLayout.tsx
+++ b/src/layouts/RecordreamLayout.tsx
@@ -1,21 +1,12 @@
 import styled from 'styled-components';
 import { IcFeelingLBlank, IcPcBlank, IcPcRecordream } from '../assets/svg';
-import Button from '../components/Button';
 import { Outlet } from 'react-router-dom';
 
 interface RecordreamLayoutInterface {
   iconOn: boolean;
-  btnColor: string;
-  btnMessage: string;
-  handleClick: VoidFunction;
 }
 
-const RecordreamLayout = ({
-  iconOn,
-  btnColor,
-  btnMessage,
-  handleClick,
-}: RecordreamLayoutInterface) => {
+const RecordreamLayout = ({ iconOn }: RecordreamLayoutInterface) => {
   return (
     <RecordreamLayoutWrapper>
       <IcPcRecordream style={{ width: 134, height: 24, marginTop: 74, marginBottom: 18 }} />
@@ -25,7 +16,6 @@ const RecordreamLayout = ({
         <IcPcBlank style={{ width: 85, height: 85, marginTop: 74, marginBottom: 18 }} />
       )}
       <Outlet />
-      <Button color={btnColor} message={btnMessage} onClick={() => handleClick} />
     </RecordreamLayoutWrapper>
   );
 };

--- a/src/pages/CompletePage.tsx
+++ b/src/pages/CompletePage.tsx
@@ -1,6 +1,8 @@
-import styled from "styled-components";
-import Subtitle from "../components/Subtitle";
-import Title from "../components/Title";
+import styled from 'styled-components';
+import Subtitle from '../components/Subtitle';
+import Title from '../components/Title';
+import Button from '../components/Button';
+import useNavigateHome from '../hooks/useNavigateHome';
 
 const CompletePage = () => {
   return (
@@ -9,6 +11,7 @@ const CompletePage = () => {
       <Subtitle>
         그동안 레코드림을 이용해주셔서 <br /> 감사합니다.
       </Subtitle>
+      <Button message="확인" onClick={useNavigateHome} />
     </CompletePageWrapper>
   );
 };

--- a/src/pages/DeletePage.tsx
+++ b/src/pages/DeletePage.tsx
@@ -1,6 +1,7 @@
-import styled from "styled-components";
-import Title from "../components/Title";
-import Subtitle from "../components/Subtitle";
+import styled from 'styled-components';
+import Title from '../components/Title';
+import Subtitle from '../components/Subtitle';
+import DeleteButton from '../components/DeleteButton';
 
 const DeletePage = () => {
   return (
@@ -9,6 +10,7 @@ const DeletePage = () => {
       <Subtitle>
         서비스 탈퇴 시 저장된 기록은 <br /> 복구되지 않습니다.
       </Subtitle>
+      <DeleteButton message="탈퇴하기" />
     </DeletePageWrapper>
   );
 };

--- a/src/pages/UnregisteredPage.tsx
+++ b/src/pages/UnregisteredPage.tsx
@@ -1,10 +1,13 @@
-import styled from "styled-components";
-import Title from "../components/Title";
+import styled from 'styled-components';
+import Title from '../components/Title';
+import useNavigateHome from '../hooks/useNavigateHome';
+import Button from '../components/Button';
 
 const UnregisteredPage = () => {
   return (
     <UnregisteredPageWrapper>
       <Title>가입된 회원이 아닙니다.</Title>
+      <Button message="확인" onClick={useNavigateHome} />
     </UnregisteredPageWrapper>
   );
 };

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -6,8 +6,8 @@ import DeletePage from '../pages/DeletePage';
 import CompletePage from '../pages/CompletePage';
 import UnregisteredPage from '../pages/UnregisteredPage';
 import KakaoLoginPage from '../pages/KakaoLoginPage';
-import { useDeleteUser } from '../hooks/queries/useDeleteUser';
-import useNavigateHome from '../hooks/useNavigateHome';
+
+import DeleteLayout from '../layouts/DeleteLayout';
 
 const router = createBrowserRouter([
   {
@@ -23,14 +23,7 @@ const router = createBrowserRouter([
         element: <KakaoLoginPage />,
       },
       {
-        element: (
-          <RecordreamLayout
-            iconOn={true}
-            btnColor="red"
-            btnMessage="탈퇴하기"
-            handleClick={useDeleteUser}
-          />
-        ),
+        element: <DeleteLayout iconOn={true} />,
         children: [
           {
             path: '/delete',
@@ -39,14 +32,7 @@ const router = createBrowserRouter([
         ],
       },
       {
-        element: (
-          <RecordreamLayout
-            iconOn={false}
-            btnColor="white"
-            btnMessage="확인"
-            handleClick={useNavigateHome}
-          />
-        ),
+        element: <RecordreamLayout iconOn={false} />,
         children: [
           { path: '/complete', element: <CompletePage /> },
           { path: '/unregistered', element: <UnregisteredPage /> },


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #27 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [ ] 탈퇴 뷰 및 이후 연결되는 뷰 레이아웃 구조 수정
- [ ] 탈퇴용, 일반 버튼 컴포넌트 따로 생성

## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->



## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
